### PR TITLE
Avoid double encoding when calling pynvrtc constructor

### DIFF
--- a/torchqrnn/forget_mult.py
+++ b/torchqrnn/forget_mult.py
@@ -99,7 +99,7 @@ class GPUForgetMult(torch.autograd.Function):
 
     def compile(self):
         if self.ptx is None:
-            program = Program(kernel.encode(), 'recurrent_forget_mult.cu'.encode())
+            program = Program(kernel, 'recurrent_forget_mult.cu')
             GPUForgetMult.ptx = program.compile()
 
         if torch.cuda.current_device() not in GPUForgetMult.configured_gpus:


### PR DESCRIPTION
pynvrtc now performs encode() of its own:
https://github.com/NVIDIA/pynvrtc/blob/fffa9f6f4a7ee1d452346cbdf68b84b5246ccffb/pynvrtc/interface.py#L200
