### PR TITLE
Avoid future warning

### DIFF
--- a/torchqrnn/forget_mult.py
+++ b/torchqrnn/forget_mult.py
@@ -202,10 +202,10 @@ if __name__ == '__main__':
     loss = resulta.pow(2).sum()
     loss.backward()
 
-    print('Result =', loss.data[0])
-    print('X grad =', a.grad.mean().data[0])
-    print('Forget grad =', forget.grad.mean().data[0])
-    print('Last H grad =', last_h.grad.mean().data[0])
+    print('Result =', loss.item())
+    print('X grad =', a.grad.mean().item())
+    print('Forget grad =', forget.grad.mean().item())
+    print('Last H grad =', last_h.grad.mean().item())
 
     x_grad_copy = a.grad.clone()
 
@@ -222,20 +222,20 @@ if __name__ == '__main__':
     loss = resultb.pow(2).sum()
     loss.backward()
 
-    print('Result =', loss.data[0])
-    print('X grad =', a.grad.mean().data[0])
-    print('Forget grad =', forget.grad.mean().data[0])
-    print('Last H grad =', last_h.grad.mean().data[0])
+    print('Result =', loss.item())
+    print('X grad =', a.grad.mean().item())
+    print('Forget grad =', forget.grad.mean().item())
+    print('Last H grad =', last_h.grad.mean().item())
 
     ###
 
     print()
     print('=-=-' * 5)
-    print('(Xgrad - Xgrad).sum() =', (x_grad_copy - a.grad).sum().data[0])
+    print('(Xgrad - Xgrad).sum() =', (x_grad_copy - a.grad).sum().item())
     print('Residual error for result')
     print('=-=-' * 5)
     residual = (resulta - resultb)
-    print(residual.abs().sum().data[0])
+    print(residual.abs().sum().item())
  
     # Had to loosen gradient checking, potentially due to general floating point badness?
     from torch.autograd import gradcheck

--- a/torchqrnn/qrnn.py
+++ b/torchqrnn/qrnn.py
@@ -197,7 +197,7 @@ if __name__ == '__main__':
     qrnn.use_cuda = False
     Z, _ = qrnn(X)
 
-    diff = (Y - Z).sum().data[0]
+    diff = (Y - Z).sum().item()
     print('Total difference between QRNN(use_cuda=True) and QRNN(use_cuda=False) results:', diff)
     assert diff < 1e-5, 'CUDA and non-CUDA QRNN layers return different results'
 


### PR DESCRIPTION
Hi, 

A part of your test codes output a warning as follows:

```
UserWarning: invalid index of a 0-dim tensor. This will be an error in PyTorch 0.5. Use tensor.item() to convert a 0-dim tensor to a Python number
```

I changed the part in order to present more easily confirmable display content.

Many thanks for your good documents