### PR TITLE
Fixes wrong parameter call with the latest version of pynvrtc

### DIFF
--- a/torchqrnn/forget_mult.py
+++ b/torchqrnn/forget_mult.py
@@ -99,7 +99,7 @@ class GPUForgetMult(torch.autograd.Function):
 
     def compile(self):
         if self.ptx is None:
-            program = Program(kernel.encode(), 'recurrent_forget_mult.cu'.encode())
+            program = Program(kernel, 'recurrent_forget_mult.cu')
             GPUForgetMult.ptx = program.compile()
 
         if torch.cuda.current_device() not in GPUForgetMult.configured_gpus:


### PR DESCRIPTION
Leaving this fix here in case someone tries to run it with python3 and recent librairies. The error I encountered was ` 'Program' object has no attribute '_program'`, which was caused by the latest version of `pynvrtc` accepting now String instead of bytes.

More details:  
https://github.com/jonas-koehler/s2cnn/issues/21#issuecomment-409488734